### PR TITLE
Feature/performance/exp rnd Ziggurat指数乱数の高速化

### DIFF
--- a/src/matsu/num/statistics/random/exp/LongSubstitutedZiggExponentialRnd.java
+++ b/src/matsu/num/statistics/random/exp/LongSubstitutedZiggExponentialRnd.java
@@ -72,8 +72,9 @@ public final class LongSubstitutedZiggExponentialRnd extends SkeletalExponential
              */
             long long64 = random.nextLong();
             int iArea = (int) (long64 & (N - 1));
-            double u = LONG_TO_DOUBLE_COEFF * (long64 >>> N_BIT);
 
+            // TODO: この部分は, 直接xを計算できるように修正可能.
+            double u = LONG_TO_DOUBLE_COEFF * (long64 >>> N_BIT);
             double x = xi[iArea + 1] * u;
             if (x < xi[iArea]) {
                 return x + x0;

--- a/src/matsu/num/statistics/random/exp/LongSubstitutedZiggExponentialRnd.java
+++ b/src/matsu/num/statistics/random/exp/LongSubstitutedZiggExponentialRnd.java
@@ -33,7 +33,10 @@ public final class LongSubstitutedZiggExponentialRnd extends SkeletalExponential
 
     private static final double LONG_TO_DOUBLE_COEFF = 1d / (1L << (64 - N_BIT));
 
-    private final double[] xi;
+    /**
+     * xi と (xi * LONG_TO_DOUBLE_COEFF) を扱う.
+     */
+    private final double[] xi_and_xiTimesCoef;
     private final double[] fi;
 
     private final Exponentiation exponentiation;
@@ -47,17 +50,22 @@ public final class LongSubstitutedZiggExponentialRnd extends SkeletalExponential
         super();
         this.exponentiation = Objects.requireNonNull(exponentiation);
 
-        xi = new double[N + 1];
+        xi_and_xiTimesCoef = new double[2 * N + 2];
         fi = new double[N + 1]; //配列サイズが2^n個にならないよう、無駄スペースあり
-        xi[N] = V_N / func(R_N);
-        xi[N - 1] = R_N;
-        fi[N - 1] = func(xi[N - 1]);
+
+        setXi(N, V_N / func(R_N));
+        setXi(N - 1, R_N);
+        fi[N - 1] = func(getXi(N - 1));
         for (int i = N - 2; i >= 1; i--) {
-            xi[i] = funcInv(fi[i + 1] + V_N / xi[i + 1]);
-            fi[i] = func(xi[i]);
+            setXi(i, funcInv(fi[i + 1] + V_N / getXi(i + 1)));
+            fi[i] = func(getXi(i));
         }
-        xi[0] = 0.0;
-        fi[0] = func(xi[0]);
+        setXi(0, 0.0);
+        fi[0] = func(getXi(0));
+
+        for (int i = 0; i <= N; i++) {
+            calcAndSetXiTimesCoeff(i, getXi(i));
+        }
     }
 
     @Override
@@ -68,15 +76,16 @@ public final class LongSubstitutedZiggExponentialRnd extends SkeletalExponential
         while (true) {
             /*
              * 処理のメインとなる randomDouble を long で代用する.
-             * u がdouble値に相当する.
+             * u = LONG_TO_DOUBLE_COEFF * (long64 >>> N_BIT)
+             * がdouble値に相当する.
              */
             long long64 = random.nextLong();
             int iArea = (int) (long64 & (N - 1));
 
-            // TODO: この部分は, 直接xを計算できるように修正可能.
-            double u = LONG_TO_DOUBLE_COEFF * (long64 >>> N_BIT);
-            double x = xi[iArea + 1] * u;
-            if (x < xi[iArea]) {
+            double xiTimesCoeff_at_iAreaPlus1 = getXiTimesCoeff(iArea + 1);
+            double xi_at_iArea = getXi(iArea);
+            double x = xiTimesCoeff_at_iAreaPlus1 * (long64 >>> N_BIT);
+            if (x < xi_at_iArea) {
                 return x + x0;
             }
             if (iArea == N - 1) {
@@ -101,6 +110,22 @@ public final class LongSubstitutedZiggExponentialRnd extends SkeletalExponential
      */
     private double funcInv(double f) {
         return -exponentiation.log(f);
+    }
+
+    private double getXi(int i) {
+        return xi_and_xiTimesCoef[i << 1];
+    }
+
+    private double getXiTimesCoeff(int i) {
+        return xi_and_xiTimesCoef[(i << 1) | 1];
+    }
+
+    private void setXi(int i, double xiValue) {
+        xi_and_xiTimesCoef[i << 1] = xiValue;
+    }
+
+    private void calcAndSetXiTimesCoeff(int i, double xiValue) {
+        xi_and_xiTimesCoef[(i << 1) | 1] = xiValue * LONG_TO_DOUBLE_COEFF;
     }
 
     /**

--- a/src/matsu/num/statistics/random/exp/LongSubstitutedZiggExponentialRnd.java
+++ b/src/matsu/num/statistics/random/exp/LongSubstitutedZiggExponentialRnd.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright © 2024 Matsuura Y.
+ * 
+ * This software is released under the MIT License.
+ * http://opensource.org/licenses/mit-license.php
+ */
+/*
+ * 2025.6.4
+ */
+package matsu.num.statistics.random.exp;
+
+import java.util.Objects;
+
+import matsu.num.statistics.random.BaseRandom;
+import matsu.num.statistics.random.ExponentialRnd;
+import matsu.num.statistics.random.lib.Exponentiation;
+
+/**
+ * long型で代替したZiggurat法により実装された, 標準指数分布に従う乱数発生器.
+ * 
+ * <p>
+ * 確率密度関数である, exp(-x)に対してZigguratを適用する.
+ * </p>
+ *
+ * @author Matsuura Y.
+ */
+public final class LongSubstitutedZiggExponentialRnd extends SkeletalExponentialRnd {
+
+    private static final int N_BIT = 7;
+    private static final int N = 1 << N_BIT;
+    private static final double R_N = 6.89831511661564d;
+    private static final double V_N = 0.00797322953955351d;
+
+    private static final double LONG_TO_DOUBLE_COEFF = 1d / (1L << (64 - N_BIT));
+
+    private final double[] xi;
+    private final double[] fi;
+
+    private final Exponentiation exponentiation;
+
+    /**
+     * 唯一のコンストラクタ.
+     * 
+     * @throws NullPointerException null
+     */
+    private LongSubstitutedZiggExponentialRnd(Exponentiation exponentiation) {
+        super();
+        this.exponentiation = Objects.requireNonNull(exponentiation);
+
+        xi = new double[N + 1];
+        fi = new double[N + 1]; //配列サイズが2^n個にならないよう、無駄スペースあり
+        xi[N] = V_N / func(R_N);
+        xi[N - 1] = R_N;
+        fi[N - 1] = func(xi[N - 1]);
+        for (int i = N - 2; i >= 1; i--) {
+            xi[i] = funcInv(fi[i + 1] + V_N / xi[i + 1]);
+            fi[i] = func(xi[i]);
+        }
+        xi[0] = 0.0;
+        fi[0] = func(xi[0]);
+    }
+
+    @Override
+    public double nextRandom(BaseRandom random) {
+
+        double x0 = 0d;
+
+        while (true) {
+            /*
+             * 処理のメインとなる randomDouble を long で代用する.
+             * u がdouble値に相当する.
+             */
+            long long64 = random.nextLong();
+            int iArea = (int) (long64 & (N - 1));
+            double u = LONG_TO_DOUBLE_COEFF * (long64 >>> N_BIT);
+
+            double x = xi[iArea + 1] * u;
+            if (x < xi[iArea]) {
+                return x + x0;
+            }
+            if (iArea == N - 1) {
+                x0 += R_N;
+                continue;
+            }
+            if (random.nextDouble() * (fi[iArea] - fi[iArea + 1]) <= func(x) - fi[iArea + 1]) {
+                return x + x0;
+            }
+        }
+    }
+
+    /**
+     * 確率密度関数.
+     */
+    private double func(double x) {
+        return exponentiation.exp(-x);
+    }
+
+    /**
+     * 確率密度関数の逆数.
+     */
+    private double funcInv(double f) {
+        return -exponentiation.log(f);
+    }
+
+    /**
+     * {@link matsu.num.statistics.random.ExponentialRnd.Factory} を生成する.
+     * 
+     * @param exponentiation 指数関数計算器
+     * @return 指数乱数のファクトリ
+     * @throws NullPointerException 引数にnullが含まれる場合
+     */
+    public static ExponentialRnd.Factory createFactory(Exponentiation exponentiation) {
+        return new ExponentialRndFactory(new LongSubstitutedZiggExponentialRnd(exponentiation));
+    }
+}

--- a/src/matsu/num/statistics/random/service/GeneratorTypes.java
+++ b/src/matsu/num/statistics/random/service/GeneratorTypes.java
@@ -5,7 +5,7 @@
  * http://opensource.org/licenses/mit-license.php
  */
 /*
- * 2025.6.4
+ * 2025.6.5
  */
 package matsu.num.statistics.random.service;
 
@@ -38,7 +38,7 @@ import matsu.num.statistics.random.binomial.DirichletBasedBinomialRnd;
 import matsu.num.statistics.random.cat.TableBasedCategoricalRnd;
 import matsu.num.statistics.random.cauchy.ZiggCauchyRnd;
 import matsu.num.statistics.random.chisq.GammaTypeChiSquaredRnd;
-import matsu.num.statistics.random.exp.ZiggExponentialRnd;
+import matsu.num.statistics.random.exp.LongSubstitutedZiggExponentialRnd;
 import matsu.num.statistics.random.fdist.BetaBasedFDistributionRnd;
 import matsu.num.statistics.random.gamma.MTTypeGammaRndFactory;
 import matsu.num.statistics.random.geo.InversionBasedGeoRnd;
@@ -186,7 +186,7 @@ public final class GeneratorTypes {
 
         EXPONENTIAL_RND = new RandomGeneratorType<>(
                 "EXPONENTIAL_RND", ExponentialRnd.Factory.class,
-                p -> ZiggExponentialRnd.createFactory(p.lib().exponentiation()));
+                p -> LongSubstitutedZiggExponentialRnd.createFactory(p.lib().exponentiation()));
 
         F_DISTRIBUTION_RND = new RandomGeneratorType<>(
                 "F_DISTRIBUTION_RND", FDistributionRnd.Factory.class,

--- a/test/matsu/num/statistics/random/exp/ExponentialFactoryForTesting.java
+++ b/test/matsu/num/statistics/random/exp/ExponentialFactoryForTesting.java
@@ -18,7 +18,7 @@ import matsu.num.statistics.random.lib.ExponentiationForTesting;
 public final class ExponentialFactoryForTesting {
 
     public static final ExponentialRnd.Factory FACTORY =
-            ZiggExponentialRnd.createFactory(ExponentiationForTesting.INSTANCE);
+            LongSubstitutedZiggExponentialRnd.createFactory(ExponentiationForTesting.INSTANCE);
 
     private ExponentialFactoryForTesting() {
     }

--- a/test/matsu/num/statistics/random/exp/LongSubstitutedZiggExponentialRndTest.java
+++ b/test/matsu/num/statistics/random/exp/LongSubstitutedZiggExponentialRndTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright © 2025 Matsuura Y.
+ * 
+ * This software is released under the MIT License.
+ * http://opensource.org/licenses/mit-license.php
+ */
+package matsu.num.statistics.random.exp;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import matsu.num.statistics.random.BaseRandom;
+import matsu.num.statistics.random.ExponentialRnd;
+import matsu.num.statistics.random.FloatingRandomGeneratorTestingFramework;
+import matsu.num.statistics.random.lib.ExponentiationForTesting;
+import matsu.num.statistics.random.speedutil.SpeedTestExecutor;
+
+/**
+ * {@link LongSubstitutedZiggExponentialRnd} クラスのテスト.
+ */
+@RunWith(Enclosed.class)
+final class LongSubstitutedZiggExponentialRndTest {
+
+    public static final Class<?> TEST_CLASS = LongSubstitutedZiggExponentialRnd.class;
+    private static final ExponentialRnd.Factory FACTORY =
+            LongSubstitutedZiggExponentialRnd.createFactory(ExponentiationForTesting.INSTANCE);
+
+    public static class 乱数のテスト {
+
+        private FloatingRandomGeneratorTestingFramework framework;
+
+        @Before
+        public void before() {
+            framework = FloatingRandomGeneratorTestingFramework
+                    .instanceOf(new TestedExponentialRandomGenerator(FACTORY.instance()));
+        }
+
+        @Test
+        public void test() {
+            framework.test();
+        }
+    }
+
+    @Ignore
+    public static class 計算時間評価 {
+
+        @Test
+        public void test_乱数生成の実行() {
+            var testRnd = FACTORY.instance();
+            BaseRandom baseRandom = BaseRandom.threadSeparatedRandom();
+
+            var myRndExecutor = new SpeedTestExecutor(
+                    TEST_CLASS, testRnd, 50_000_000,
+                    () -> testRnd.nextRandom(baseRandom));
+            myRndExecutor.execute();
+
+            var javaApiExecutor = new SpeedTestExecutor(
+                    null, "ThreadLocalRandom.nextExponential", 50_000_000,
+                    () -> ThreadLocalRandom.current().nextExponential());
+            javaApiExecutor.execute();
+        }
+    }
+
+    public static class toString表示 {
+
+        @Test
+        public void test_toString() {
+            System.out.println(TEST_CLASS.getName());
+            System.out.println(FACTORY);
+            System.out.println(FACTORY.instance());
+            System.out.println();
+        }
+    }
+}


### PR DESCRIPTION
Ziggurat指数乱数の高速化:
基本乱数について, doubleをlongに変更し, 乱数生成の回数を減らした.