### PR TITLE
Feature/avoid-expRnd-and-normRnd ExponentialRndとNormalRndの回避

### DIFF
--- a/src/matsu/num/statistics/random/gamma/ExpBasedGammaRndAt1.java
+++ b/src/matsu/num/statistics/random/gamma/ExpBasedGammaRndAt1.java
@@ -4,13 +4,13 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
+
 /*
- * 2024.9.28
+ * 2026.5.27
  */
 package matsu.num.statistics.random.gamma;
 
 import matsu.num.statistics.random.BaseRandom;
-import matsu.num.statistics.random.ExponentialRnd;
 
 /**
  * 標準指数乱数によって実装された, 形状パラメータが1の乱数発生器.
@@ -19,15 +19,12 @@ import matsu.num.statistics.random.ExponentialRnd;
  */
 final class ExpBasedGammaRndAt1 extends SkeletalGammaRnd {
 
-    private final ExponentialRnd expRnd;
-
-    ExpBasedGammaRndAt1(ExponentialRnd.Factory exponentialRndFactory) {
+    ExpBasedGammaRndAt1() {
         super(1d);
-        this.expRnd = exponentialRndFactory.instance();
     }
 
     @Override
     public double nextRandom(BaseRandom random) {
-        return expRnd.nextRandom(random);
+        return random.nextExponential();
     }
 }

--- a/src/matsu/num/statistics/random/gamma/MTTypeGammaRndFactory.java
+++ b/src/matsu/num/statistics/random/gamma/MTTypeGammaRndFactory.java
@@ -4,16 +4,15 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
+
 /*
- * 2025.5.7
+ * 2026.5.27
  */
 package matsu.num.statistics.random.gamma;
 
 import java.util.Objects;
 
-import matsu.num.statistics.random.ExponentialRnd;
 import matsu.num.statistics.random.GammaRnd;
-import matsu.num.statistics.random.NormalRnd;
 import matsu.num.statistics.random.lib.Exponentiation;
 
 /**
@@ -26,46 +25,35 @@ public final class MTTypeGammaRndFactory extends SkeletalGammaRnd.Factory {
     private final GammaRnd gammaRndAt1;
 
     private final Exponentiation exponentiation;
-    private final ExponentialRnd.Factory exponentialRndFactory;
-    private final NormalRnd.Factory normalRndFactory;
 
-    private MTTypeGammaRndFactory(
-            Exponentiation exponentiation,
-            ExponentialRnd.Factory exponentialRndFactory, NormalRnd.Factory normalRndFactory) {
+    private MTTypeGammaRndFactory(Exponentiation exponentiation) {
 
         super();
         this.exponentiation = Objects.requireNonNull(exponentiation);
-        this.exponentialRndFactory = Objects.requireNonNull(exponentialRndFactory);
-        this.gammaRndAt1 = new ExpBasedGammaRndAt1(this.exponentialRndFactory);
-        this.normalRndFactory = Objects.requireNonNull(normalRndFactory);
+        this.gammaRndAt1 = new ExpBasedGammaRndAt1();
     }
 
     @Override
     GammaRnd createInstanceOf(double k) {
         //MarsagliaTsangに基づく乱数発生器
         if (k < 1) {
-            return new MTTypeGammaRndUnder1(
-                    k, this.exponentiation, this.exponentialRndFactory, this.normalRndFactory);
+            return new MTTypeGammaRndUnder1(k, this.exponentiation);
         }
         if (k == 1) {
             return gammaRndAt1;
         }
 
-        return new MTTypeGammaRndOver1(k, this.exponentiation, this.normalRndFactory);
+        return new MTTypeGammaRndOver1(k, this.exponentiation);
     }
 
     /**
      * Marsaglia-Tsangに基づく {@link GammaRnd} のファクトリインスタンスを生成する.
      * 
      * @param exponentiation 指数関数の計算
-     * @param exponentialRndFactory 指数乱数生成器のファクトリ
-     * @param normalRndFactory 正規乱数生成器のファクトリ
      * @return 乱数生成器ファクトリ
      * @throws NullPointerException 引数にnullが含まれる場合
      */
-    public static GammaRnd.Factory create(
-            Exponentiation exponentiation,
-            ExponentialRnd.Factory exponentialRndFactory, NormalRnd.Factory normalRndFactory) {
-        return new MTTypeGammaRndFactory(exponentiation, exponentialRndFactory, normalRndFactory);
+    public static GammaRnd.Factory create(Exponentiation exponentiation) {
+        return new MTTypeGammaRndFactory(exponentiation);
     }
 }

--- a/src/matsu/num/statistics/random/gamma/MTTypeGammaRndOver1.java
+++ b/src/matsu/num/statistics/random/gamma/MTTypeGammaRndOver1.java
@@ -4,13 +4,13 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
+
 /*
- * 2025.6.7
+ * 2026.5.27
  */
 package matsu.num.statistics.random.gamma;
 
 import matsu.num.statistics.random.BaseRandom;
-import matsu.num.statistics.random.NormalRnd;
 import matsu.num.statistics.random.lib.Exponentiation;
 
 /**
@@ -23,19 +23,17 @@ final class MTTypeGammaRndOver1 extends SkeletalGammaRnd {
     //Gamma(k)乱数を発生させるためのdとc
     private final double d;
     private final double c;
-    private final NormalRnd normalRnd;
 
     private final Exponentiation exponentiation;
 
     /**
      * @param k 1<=k<=1E28
      */
-    MTTypeGammaRndOver1(double k, Exponentiation exponentiation, NormalRnd.Factory normalRndFactory) {
+    MTTypeGammaRndOver1(double k, Exponentiation exponentiation) {
         super(k);
 
         assert 1 <= k : "not 1 <= k";
 
-        this.normalRnd = normalRndFactory.instance();
         this.exponentiation = exponentiation;
         this.d = k - (1.0 / 3.0);
         this.c = (1.0 / 3.0) / exponentiation.sqrt(d);
@@ -48,7 +46,7 @@ final class MTTypeGammaRndOver1 extends SkeletalGammaRnd {
          * ただし, d = k - 1/3, c = 1/sqrt(9d)
          */
         while (true) {
-            double z = this.normalRnd.nextRandom(random);
+            double z = random.nextGaussian();
             double v = 1 + c * z;
             double w = v * v * v;
             double y = d * w;

--- a/src/matsu/num/statistics/random/gamma/MTTypeGammaRndUnder1.java
+++ b/src/matsu/num/statistics/random/gamma/MTTypeGammaRndUnder1.java
@@ -4,15 +4,14 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
+
 /*
- * 2025.6.13
+ * 2026.5.27
  */
 package matsu.num.statistics.random.gamma;
 
 import matsu.num.statistics.random.BaseRandom;
-import matsu.num.statistics.random.ExponentialRnd;
 import matsu.num.statistics.random.GammaRnd;
-import matsu.num.statistics.random.NormalRnd;
 import matsu.num.statistics.random.lib.Exponentiation;
 
 /**
@@ -27,23 +26,19 @@ final class MTTypeGammaRndUnder1 extends SkeletalGammaRnd {
     private final GammaRnd gammaKPlus1;
     private final double invK;
 
-    private final ExponentialRnd expRnd;
-
     private final Exponentiation exponentiation;
 
     /**
      * @param k 0.01<=k<=1
      */
-    MTTypeGammaRndUnder1(double k, Exponentiation exponentiation,
-            ExponentialRnd.Factory exponentialRndFactory, NormalRnd.Factory normalRndFactory) {
+    MTTypeGammaRndUnder1(double k, Exponentiation exponentiation) {
         super(k);
 
         assert k <= 1 : "not k <= 1";
 
         this.exponentiation = exponentiation;
-        this.gammaKPlus1 = new MTTypeGammaRndOver1(k + 1, exponentiation, normalRndFactory);
+        this.gammaKPlus1 = new MTTypeGammaRndOver1(k + 1, exponentiation);
         this.invK = 1 / k;
-        this.expRnd = exponentialRndFactory.instance();
     }
 
     @Override
@@ -61,7 +56,7 @@ final class MTTypeGammaRndUnder1 extends SkeletalGammaRnd {
         double out;
         do {
             out = this.gammaKPlus1.nextRandom(random) *
-                    exponentiation.exp(-this.expRnd.nextRandom(random) * this.invK);
+                    exponentiation.exp(-random.nextExponential() * this.invK);
 
             // outが (0 * inf)　となった場合のフォロー
         } while (Double.isNaN(out));

--- a/src/matsu/num/statistics/random/geo/InversionBasedGeoRnd.java
+++ b/src/matsu/num/statistics/random/geo/InversionBasedGeoRnd.java
@@ -4,15 +4,15 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
+
 /*
- * 2025.5.7
+ * 2026.5.27
  */
 package matsu.num.statistics.random.geo;
 
 import java.util.Objects;
 
 import matsu.num.statistics.random.BaseRandom;
-import matsu.num.statistics.random.ExponentialRnd;
 import matsu.num.statistics.random.GeometricRnd;
 import matsu.num.statistics.random.lib.Exponentiation;
 
@@ -25,20 +25,17 @@ public final class InversionBasedGeoRnd extends SkeletalGeometricRnd {
 
     private final double coeff;
 
-    private final ExponentialRnd expRnd;
-
     private InversionBasedGeoRnd(
-            double p, Exponentiation exponentiation, ExponentialRnd.Factory exponentialRndFactory) {
+            double p, Exponentiation exponentiation) {
         super(p);
 
         this.coeff = -1 / exponentiation.log1p(-p);
-        this.expRnd = exponentialRndFactory.instance();
     }
 
     @Override
     public int nextRandom(BaseRandom random) {
         while (true) {
-            double out = coeff * this.expRnd.nextRandom(random);
+            double out = coeff * random.nextExponential();
             if (out < Integer.MAX_VALUE) {
                 return 1 + (int) out;
             }
@@ -49,16 +46,12 @@ public final class InversionBasedGeoRnd extends SkeletalGeometricRnd {
      * 逆関数法に基づく {@link GeometricRnd} のファクトリインスタンスを生成する.
      * 
      * @param exponentiation 指数関数の計算
-     * @param exponentialRndFactory 指数乱数のファクトリ
      * @return 乱数生成器ファクトリ
      * @throws NullPointerException 引数にnullが含まれる場合
      */
-    public static GeometricRnd.Factory createFactory(
-            Exponentiation exponentiation, ExponentialRnd.Factory exponentialRndFactory) {
+    public static GeometricRnd.Factory createFactory(Exponentiation exponentiation) {
 
-        return new Factory(
-                Objects.requireNonNull(exponentiation),
-                Objects.requireNonNull(exponentialRndFactory));
+        return new Factory(Objects.requireNonNull(exponentiation));
     }
 
     /**
@@ -67,17 +60,14 @@ public final class InversionBasedGeoRnd extends SkeletalGeometricRnd {
     private static final class Factory extends SkeletalGeometricRnd.Factory {
 
         private final Exponentiation exponentiation;
-        private final ExponentialRnd.Factory exponentialRndFactory;
 
-        Factory(
-                Exponentiation exponentiation, ExponentialRnd.Factory exponentialRndFactory) {
+        Factory(Exponentiation exponentiation) {
             this.exponentiation = exponentiation;
-            this.exponentialRndFactory = exponentialRndFactory;
         }
 
         @Override
         GeometricRnd createInstanceOf(double p) {
-            return new InversionBasedGeoRnd(p, this.exponentiation, this.exponentialRndFactory);
+            return new InversionBasedGeoRnd(p, this.exponentiation);
         }
     }
 }

--- a/src/matsu/num/statistics/random/gumbel/UniZiggGumbelRnd.java
+++ b/src/matsu/num/statistics/random/gumbel/UniZiggGumbelRnd.java
@@ -4,15 +4,15 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
+
 /*
- * 2025.6.7
+ * 2026.5.27
  */
 package matsu.num.statistics.random.gumbel;
 
 import java.util.Objects;
 
 import matsu.num.statistics.random.BaseRandom;
-import matsu.num.statistics.random.ExponentialRnd;
 import matsu.num.statistics.random.GumbelRnd;
 import matsu.num.statistics.random.lib.Exponentiation;
 
@@ -40,8 +40,6 @@ public final class UniZiggGumbelRnd extends SkeletalGumbelRnd {
     private static final double EXP_R_LOWER = Math.exp(R_LOWER);
 
     private final Exponentiation exponentiation;
-
-    private final ExponentialRnd expRnd;
 
     private final double[] X_LOWER = {
             0.0, -0.2673193376281921, -0.3510237686340313, -0.4084427617247585,
@@ -179,10 +177,9 @@ public final class UniZiggGumbelRnd extends SkeletalGumbelRnd {
      * 
      * @throws NullPointerException null
      */
-    private UniZiggGumbelRnd(Exponentiation exponentiation, ExponentialRnd.Factory exponentialRndFactory) {
+    private UniZiggGumbelRnd(Exponentiation exponentiation) {
         super();
         this.exponentiation = Objects.requireNonNull(exponentiation);
-        this.expRnd = exponentialRndFactory.instance();
     }
 
     @Override
@@ -210,15 +207,15 @@ public final class UniZiggGumbelRnd extends SkeletalGumbelRnd {
 
     private double tail_p(BaseRandom random) {
         while (true) {
-            double z = R_UPPER + this.expRnd.nextRandom(random);
-            if (1 < exponentiation.exp(z) * this.expRnd.nextRandom(random)) {
+            double z = R_UPPER + random.nextExponential();
+            if (1 < exponentiation.exp(z) * random.nextExponential()) {
                 return z;
             }
         }
     }
 
     private double tail_m(BaseRandom random) {
-        return -exponentiation.log(EXP_R_LOWER + this.expRnd.nextRandom(random));
+        return -exponentiation.log(EXP_R_LOWER + random.nextExponential());
     }
 
     /**
@@ -234,13 +231,11 @@ public final class UniZiggGumbelRnd extends SkeletalGumbelRnd {
      * {@link matsu.num.statistics.random.GumbelRnd.Factory} を生成する.
      * 
      * @param exponentiation 指数関数計算器
-     * @param exponentialRndFactory 指数乱数発生器のファクトリ
      * @return Gumbel乱数のファクトリ
      * @throws NullPointerException 引数にnullが含まれる場合
      */
-    public static GumbelRnd.Factory createFactory(
-            Exponentiation exponentiation, ExponentialRnd.Factory exponentialRndFactory) {
+    public static GumbelRnd.Factory createFactory(Exponentiation exponentiation) {
         return new LazyGumbelRndFactory(
-                () -> new UniZiggGumbelRnd(exponentiation, exponentialRndFactory));
+                () -> new UniZiggGumbelRnd(exponentiation));
     }
 }

--- a/src/matsu/num/statistics/random/levy/NormalBasedLevyRnd.java
+++ b/src/matsu/num/statistics/random/levy/NormalBasedLevyRnd.java
@@ -4,14 +4,14 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
+
 /*
- * 2025.6.13
+ * 2026.5.27
  */
 package matsu.num.statistics.random.levy;
 
 import matsu.num.statistics.random.BaseRandom;
 import matsu.num.statistics.random.LevyRnd;
-import matsu.num.statistics.random.NormalRnd;
 
 /**
  * 標準正規分布を用いた, 標準L&eacute;vy乱数発生器.
@@ -20,28 +20,24 @@ import matsu.num.statistics.random.NormalRnd;
  */
 public final class NormalBasedLevyRnd extends SkeletalLevyRnd {
 
-    private final NormalRnd normalRnd;
-
-    private NormalBasedLevyRnd(NormalRnd.Factory normalRndFactory) {
+    private NormalBasedLevyRnd() {
         super();
-        this.normalRnd = normalRndFactory.instance();
     }
 
     @Override
     public double nextRandom(BaseRandom random) {
-        double y = this.normalRnd.nextRandom(random);
+        double y = random.nextGaussian();
         return 1 / (y * y);
     }
 
     /**
      * {@link matsu.num.statistics.random.LevyRnd.Factory} を生成する.
      * 
-     * @param normalRndFactory 正規乱数発生器のファクトリ
      * @return Levy乱数のファクトリ
      * @throws NullPointerException 引数にnullが含まれる場合
      */
-    public static LevyRnd.Factory createFactory(NormalRnd.Factory normalRndFactory) {
+    public static LevyRnd.Factory createFactory() {
         return new LazyLevyRndFactory(
-                () -> new NormalBasedLevyRnd(normalRndFactory));
+                () -> new NormalBasedLevyRnd());
     }
 }

--- a/src/matsu/num/statistics/random/logi/ZiggLogiRnd.java
+++ b/src/matsu/num/statistics/random/logi/ZiggLogiRnd.java
@@ -4,15 +4,15 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
+
 /*
- * 2025.6.7
+ * 2026.5.27
  */
 package matsu.num.statistics.random.logi;
 
 import java.util.Objects;
 
 import matsu.num.statistics.random.BaseRandom;
-import matsu.num.statistics.random.ExponentialRnd;
 import matsu.num.statistics.random.LogisticRnd;
 import matsu.num.statistics.random.lib.Exponentiation;
 
@@ -34,14 +34,12 @@ public final class ZiggLogiRnd extends SkeletalLogisticRnd {
 
     private final double[] xi;
     private final double[] fi;
-    private final ExponentialRnd expRnd;
 
     private final Exponentiation exponentiation;
 
-    private ZiggLogiRnd(Exponentiation exponentiation, ExponentialRnd.Factory exponentialRndFactory) {
+    private ZiggLogiRnd(Exponentiation exponentiation) {
         super();
         this.exponentiation = Objects.requireNonNull(exponentiation);
-        this.expRnd = exponentialRndFactory.instance();
 
         xi = new double[N + 1];
         fi = new double[N + 1]; //配列サイズが2^n個にならないよう、無駄スペースあり
@@ -95,7 +93,7 @@ public final class ZiggLogiRnd extends SkeletalLogisticRnd {
 
     private double tail(BaseRandom random) {
         while (true) {
-            double u = this.expRnd.nextRandom(random);
+            double u = random.nextExponential();
             double u2 = random.nextDouble();
             double thre1 = 1 - u + u * u * 0.5;
             thre1 = 1 / (1 + EXP_NEGATIVE_R * thre1);
@@ -116,15 +114,13 @@ public final class ZiggLogiRnd extends SkeletalLogisticRnd {
      * {@link matsu.num.statistics.random.LogisticRnd.Factory} を生成する.
      * 
      * @param exponentiation 指数関数計算器
-     * @param exponentialRndFactory 正規乱数発生器のファクトリ
      * @return Logistic乱数のファクトリ
      * @throws NullPointerException 引数にnullが含まれる場合
      */
     public static LogisticRnd.Factory createFactory(
-            Exponentiation exponentiation,
-            ExponentialRnd.Factory exponentialRndFactory) {
+            Exponentiation exponentiation) {
 
         return new LazyLogisticRndFactory(
-                () -> new ZiggLogiRnd(exponentiation, exponentialRndFactory));
+                () -> new ZiggLogiRnd(exponentiation));
     }
 }

--- a/src/matsu/num/statistics/random/logseries/GeometricMixBasedLogarithmicSeriesRnd.java
+++ b/src/matsu/num/statistics/random/logseries/GeometricMixBasedLogarithmicSeriesRnd.java
@@ -6,14 +6,13 @@
  */
 
 /*
- * 2025.6.10
+ * 2026.5.27
  */
 package matsu.num.statistics.random.logseries;
 
 import java.util.Objects;
 
 import matsu.num.statistics.random.BaseRandom;
-import matsu.num.statistics.random.ExponentialRnd;
 import matsu.num.statistics.random.LogarithmicSeriesRnd;
 import matsu.num.statistics.random.lib.Exponentiation;
 
@@ -50,7 +49,6 @@ public final class GeometricMixBasedLogarithmicSeriesRnd
         extends SkeletalLogarithmicSeriesRnd {
 
     private final Exponentiation exponentiation;
-    private final ExponentialRnd exponentialRnd;
 
     private final double log1mp;
     private final double mlogp;
@@ -61,12 +59,10 @@ public final class GeometricMixBasedLogarithmicSeriesRnd
      */
     private GeometricMixBasedLogarithmicSeriesRnd(
             double p,
-            Exponentiation exponentiation,
-            ExponentialRnd.Factory exponentialRndFactory) {
+            Exponentiation exponentiation) {
         super(p);
 
         this.exponentiation = exponentiation;
-        this.exponentialRnd = exponentialRndFactory.instance();
         this.log1mp = exponentiation.log1p(-p);
         this.mlogp = -exponentiation.log(p);
     }
@@ -81,7 +77,7 @@ public final class GeometricMixBasedLogarithmicSeriesRnd
              * y = 1 - (1 - p)^u は0からpまでを動くので,
              * e <= -log(p)ならばfloor(w) = 0
              */
-            double e = exponentialRnd.nextRandom(random);
+            double e = random.nextExponential();
             if (e <= this.mlogp) {
                 return 1;
             }
@@ -105,37 +101,31 @@ public final class GeometricMixBasedLogarithmicSeriesRnd
      * ファクトリを生成して返す.
      * 
      * @param exponentiation 指数関数の計算
-     * @param exponentialRndFactory 指数乱数生成器のファクトリ
      * @return ファクトリ
      * @throws NullPointerException 引数にnullが含まれる場合
      */
-    public static LogarithmicSeriesRnd.Factory createFactory(
-            Exponentiation exponentiation, ExponentialRnd.Factory exponentialRndFactory) {
+    public static LogarithmicSeriesRnd.Factory createFactory(Exponentiation exponentiation) {
         return new Factory(
-                Objects.requireNonNull(exponentiation),
-                Objects.requireNonNull(exponentialRndFactory));
+                Objects.requireNonNull(exponentiation));
     }
 
     private static final class Factory extends SkeletalLogarithmicSeriesRnd.Factory {
 
         private final Exponentiation exponentiation;
-        private final ExponentialRnd.Factory exponentialRndFactory;
 
         /**
          * staticメソッドから呼ばれる.
          */
-        Factory(Exponentiation exponentiation,
-                ExponentialRnd.Factory exponentialRndFactory) {
+        Factory(Exponentiation exponentiation) {
             super();
 
             this.exponentiation = exponentiation;
-            this.exponentialRndFactory = exponentialRndFactory;
         }
 
         @Override
         LogarithmicSeriesRnd createInstanceOf(double p) {
             return new GeometricMixBasedLogarithmicSeriesRnd(
-                    p, exponentiation, exponentialRndFactory);
+                    p, exponentiation);
         }
     }
 

--- a/src/matsu/num/statistics/random/service/GeneratorTypes.java
+++ b/src/matsu/num/statistics/random/service/GeneratorTypes.java
@@ -218,7 +218,7 @@ public final class GeneratorTypes {
         GUMBEL_RND = new RandomGeneratorType<>(
                 "GUMBEL_RND", GumbelRnd.Factory.class,
                 p -> UniZiggGumbelRnd.createFactory(
-                        p.lib().exponentiation(), p.get(GeneratorTypes.EXPONENTIAL_RND)));
+                        p.lib().exponentiation()));
 
         LEVY_RND = new RandomGeneratorType<>(
                 "LEVY_RND", LevyRnd.Factory.class,

--- a/src/matsu/num/statistics/random/service/GeneratorTypes.java
+++ b/src/matsu/num/statistics/random/service/GeneratorTypes.java
@@ -4,8 +4,9 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
+
 /*
- * 2025.6.10
+ * 2026.5.27
  */
 package matsu.num.statistics.random.service;
 
@@ -212,7 +213,7 @@ public final class GeneratorTypes {
         GEOMETRIC_RND = new RandomGeneratorType<>(
                 "GEOMETRIC_RND", GeometricRnd.Factory.class,
                 p -> InversionBasedGeoRnd.createFactory(
-                        p.lib().exponentiation(), p.get(GeneratorTypes.EXPONENTIAL_RND)));
+                        p.lib().exponentiation()));
 
         GUMBEL_RND = new RandomGeneratorType<>(
                 "GUMBEL_RND", GumbelRnd.Factory.class,

--- a/src/matsu/num/statistics/random/service/GeneratorTypes.java
+++ b/src/matsu/num/statistics/random/service/GeneratorTypes.java
@@ -267,7 +267,7 @@ public final class GeneratorTypes {
                 "T_DISTRIBUTION_RND", TDistributionRnd.Factory.class,
                 p -> NormalGammaBasedTDistRnd.createFactory(
                         p.lib().exponentiation(),
-                        p.get(GeneratorTypes.NORMAL_RND), p.get(GeneratorTypes.GAMMA_RND)));
+                        p.get(GeneratorTypes.GAMMA_RND)));
 
         VOIGT_RND = new RandomGeneratorType<>(
                 "VOIGT_RND", VoigtRnd.Factory.class,

--- a/src/matsu/num/statistics/random/service/GeneratorTypes.java
+++ b/src/matsu/num/statistics/random/service/GeneratorTypes.java
@@ -287,8 +287,7 @@ public final class GeneratorTypes {
         ZETA_RND = new RandomGeneratorType<>(
                 "ZETA_RND", ZetaRnd.Factory.class,
                 p -> RejectionSamplingZetaRnd.createFactory(
-                        p.lib().exponentiation(),
-                        p.get(GeneratorTypes.EXPONENTIAL_RND)));
+                        p.lib().exponentiation()));
     }
 
     private GeneratorTypes() {

--- a/src/matsu/num/statistics/random/service/GeneratorTypes.java
+++ b/src/matsu/num/statistics/random/service/GeneratorTypes.java
@@ -222,7 +222,7 @@ public final class GeneratorTypes {
 
         LEVY_RND = new RandomGeneratorType<>(
                 "LEVY_RND", LevyRnd.Factory.class,
-                p -> NormalBasedLevyRnd.createFactory(p.get(GeneratorTypes.NORMAL_RND)));
+                p -> NormalBasedLevyRnd.createFactory());
 
         LOGARITHMIC_SERIES_RND = new RandomGeneratorType<>(
                 "LOGARITHMIC_SERIES_RND", LogarithmicSeriesRnd.Factory.class,

--- a/src/matsu/num/statistics/random/service/GeneratorTypes.java
+++ b/src/matsu/num/statistics/random/service/GeneratorTypes.java
@@ -261,8 +261,7 @@ public final class GeneratorTypes {
         STATIC_GAMMA_RND = new RandomGeneratorType<>(
                 "STATIC_GAMMA_RND", StaticGammaRnd.Factory.class,
                 p -> MTTypeStaticGammaRnd.createFactory(
-                        p.lib().exponentiation(),
-                        p.get(GeneratorTypes.EXPONENTIAL_RND), p.get(GeneratorTypes.NORMAL_RND)));
+                        p.lib().exponentiation()));
 
         T_DISTRIBUTION_RND = new RandomGeneratorType<>(
                 "T_DISTRIBUTION_RND", TDistributionRnd.Factory.class,

--- a/src/matsu/num/statistics/random/service/GeneratorTypes.java
+++ b/src/matsu/num/statistics/random/service/GeneratorTypes.java
@@ -272,7 +272,7 @@ public final class GeneratorTypes {
         VOIGT_RND = new RandomGeneratorType<>(
                 "VOIGT_RND", VoigtRnd.Factory.class,
                 p -> StandardImplVoigtRnd.createFactory(
-                        p.get(GeneratorTypes.NORMAL_RND), p.get(GeneratorTypes.CAUCHY_RND)));
+                        p.get(GeneratorTypes.CAUCHY_RND)));
 
         WEIBULL_RND = new RandomGeneratorType<>(
                 "WEIBULL_RND", WeibullRnd.Factory.class,

--- a/src/matsu/num/statistics/random/service/GeneratorTypes.java
+++ b/src/matsu/num/statistics/random/service/GeneratorTypes.java
@@ -207,8 +207,7 @@ public final class GeneratorTypes {
         GAMMA_RND = new RandomGeneratorType<>(
                 "GAMMA_RND", GammaRnd.Factory.class,
                 p -> MTTypeGammaRndFactory.create(
-                        p.lib().exponentiation(),
-                        p.get(GeneratorTypes.EXPONENTIAL_RND), p.get(GeneratorTypes.NORMAL_RND)));
+                        p.lib().exponentiation()));
 
         GEOMETRIC_RND = new RandomGeneratorType<>(
                 "GEOMETRIC_RND", GeometricRnd.Factory.class,

--- a/src/matsu/num/statistics/random/service/GeneratorTypes.java
+++ b/src/matsu/num/statistics/random/service/GeneratorTypes.java
@@ -282,8 +282,7 @@ public final class GeneratorTypes {
         YULE_SIMON_RND = new RandomGeneratorType<>(
                 "YULE_SIMON_RND", YuleSimonRnd.Factory.class,
                 p -> ExpGeometricBasedYuleSimonRnd.createFactory(
-                        p.lib().exponentiation(),
-                        p.get(GeneratorTypes.EXPONENTIAL_RND)));
+                        p.lib().exponentiation()));
 
         ZETA_RND = new RandomGeneratorType<>(
                 "ZETA_RND", ZetaRnd.Factory.class,

--- a/src/matsu/num/statistics/random/service/GeneratorTypes.java
+++ b/src/matsu/num/statistics/random/service/GeneratorTypes.java
@@ -227,7 +227,7 @@ public final class GeneratorTypes {
         LOGARITHMIC_SERIES_RND = new RandomGeneratorType<>(
                 "LOGARITHMIC_SERIES_RND", LogarithmicSeriesRnd.Factory.class,
                 p -> GeometricMixBasedLogarithmicSeriesRnd.createFactory(
-                        p.lib().exponentiation(), p.get(GeneratorTypes.EXPONENTIAL_RND)));
+                        p.lib().exponentiation()));
 
         LOGISTIC_RND = new RandomGeneratorType<>(
                 "LOGISTIC_RND", LogisticRnd.Factory.class,

--- a/src/matsu/num/statistics/random/service/GeneratorTypes.java
+++ b/src/matsu/num/statistics/random/service/GeneratorTypes.java
@@ -232,7 +232,7 @@ public final class GeneratorTypes {
         LOGISTIC_RND = new RandomGeneratorType<>(
                 "LOGISTIC_RND", LogisticRnd.Factory.class,
                 p -> ZiggLogiRnd.createFactory(
-                        p.lib().exponentiation(), p.get(GeneratorTypes.EXPONENTIAL_RND)));
+                        p.lib().exponentiation()));
 
         NEGATIVE_BINOMIAL_RND = new RandomGeneratorType<>(
                 "NEGATIVE_BINOMIAL_RND", NegativeBinomialRnd.Factory.class,

--- a/src/matsu/num/statistics/random/staticgamma/MTTypeStaticGammaRnd.java
+++ b/src/matsu/num/statistics/random/staticgamma/MTTypeStaticGammaRnd.java
@@ -4,16 +4,15 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
+
 /*
- * 2025.6.13
+ * 2026.5.27
  */
 package matsu.num.statistics.random.staticgamma;
 
 import java.util.Objects;
 
 import matsu.num.statistics.random.BaseRandom;
-import matsu.num.statistics.random.ExponentialRnd;
-import matsu.num.statistics.random.NormalRnd;
 import matsu.num.statistics.random.StaticGammaRnd;
 import matsu.num.statistics.random.lib.Exponentiation;
 
@@ -24,23 +23,17 @@ import matsu.num.statistics.random.lib.Exponentiation;
  */
 public final class MTTypeStaticGammaRnd extends SkeletalStaticGammaRnd {
 
-    private final ExponentialRnd expRnd;
-    private final NormalRnd normalRnd;
-
     private final Exponentiation exponentiation;
 
-    private MTTypeStaticGammaRnd(Exponentiation exponentiation, ExponentialRnd.Factory exponentialRndFactory,
-            NormalRnd.Factory normalRndFactory) {
+    private MTTypeStaticGammaRnd(Exponentiation exponentiation) {
         super();
         this.exponentiation = Objects.requireNonNull(exponentiation);
-        this.expRnd = exponentialRndFactory.instance();
-        this.normalRnd = normalRndFactory.instance();
     }
 
     @Override
     double calcNextGamma(BaseRandom random, double k) {
         if (k == 1) {
-            return this.expRnd.nextRandom(random);
+            return random.nextExponential();
         }
         if (k > 1) {
             double d = k - (1.0 / 3.0);
@@ -54,7 +47,7 @@ public final class MTTypeStaticGammaRnd extends SkeletalStaticGammaRnd {
             double d = k + (2.0 / 3.0);
             double c = (1.0 / 3.0) / exponentiation.sqrt(d);
             out = nextGammaOver1(random, d, c) *
-                    exponentiation.exp(-this.expRnd.nextRandom(random) / k);
+                    exponentiation.exp(-random.nextExponential() / k);
 
             // outが (0 * inf)　となった場合のフォロー
         } while (Double.isNaN(out));
@@ -64,7 +57,7 @@ public final class MTTypeStaticGammaRnd extends SkeletalStaticGammaRnd {
 
     private double nextGammaOver1(BaseRandom random, double d, double c) {
         while (true) {
-            double z = this.normalRnd.nextRandom(random);
+            double z = random.nextGaussian();
             double v = 1 + c * z;
             double w = v * v * v;
             double y = d * w;
@@ -83,18 +76,13 @@ public final class MTTypeStaticGammaRnd extends SkeletalStaticGammaRnd {
      * {@link matsu.num.statistics.random.StaticGammaRnd.Factory} を生成する.
      * 
      * @param exponentiation 指数関数計算器
-     * @param exponentialRndFactory 指数乱数発生器のファクトリ
-     * @param normalRndFactory 正規乱数発生器のファクトリ
      * @return StaticGammaRnd乱数のファクトリ
      * @throws NullPointerException 引数にnullが含まれる場合
      */
     public static StaticGammaRnd.Factory createFactory(
-            Exponentiation exponentiation,
-            ExponentialRnd.Factory exponentialRndFactory,
-            NormalRnd.Factory normalRndFactory) {
+            Exponentiation exponentiation) {
 
         return new LazyStaticGammaRndFactory(
-                () -> new MTTypeStaticGammaRnd(
-                        exponentiation, exponentialRndFactory, normalRndFactory));
+                () -> new MTTypeStaticGammaRnd(exponentiation));
     }
 }

--- a/src/matsu/num/statistics/random/tdist/NormalGammaBasedTDistRnd.java
+++ b/src/matsu/num/statistics/random/tdist/NormalGammaBasedTDistRnd.java
@@ -4,8 +4,9 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
+
 /*
- * 2025.6.13
+ * 2026.5.27
  */
 package matsu.num.statistics.random.tdist;
 
@@ -13,7 +14,6 @@ import java.util.Objects;
 
 import matsu.num.statistics.random.BaseRandom;
 import matsu.num.statistics.random.GammaRnd;
-import matsu.num.statistics.random.NormalRnd;
 import matsu.num.statistics.random.TDistributionRnd;
 import matsu.num.statistics.random.lib.Exponentiation;
 
@@ -25,7 +25,6 @@ import matsu.num.statistics.random.lib.Exponentiation;
 public final class NormalGammaBasedTDistRnd extends SkeletalTDistributionRnd {
 
     private final GammaRnd gammaRnd;
-    private final NormalRnd normalRnd;
     private final Exponentiation exponentiation;
 
     /**
@@ -40,12 +39,10 @@ public final class NormalGammaBasedTDistRnd extends SkeletalTDistributionRnd {
      */
     private NormalGammaBasedTDistRnd(double nu,
             Exponentiation exponentiation,
-            NormalRnd.Factory normalRndFactory,
             GammaRnd.Factory gammaRndFactory) {
         super(nu);
 
         this.exponentiation = exponentiation;
-        this.normalRnd = normalRndFactory.instance();
         this.gammaRnd = gammaRndFactory.instanceOf(nu * 0.5);
     }
 
@@ -53,7 +50,7 @@ public final class NormalGammaBasedTDistRnd extends SkeletalTDistributionRnd {
     public final double nextRandom(BaseRandom random) {
         double out;
         do {
-            out = this.normalRnd.nextRandom(random)
+            out = random.nextGaussian()
                     / exponentiation.sqrt(this.gammaRnd.nextRandom(random) * 2 / this.nu);
 
             // outが (0/0) や (inf/inf)　となった場合のフォロー
@@ -65,19 +62,16 @@ public final class NormalGammaBasedTDistRnd extends SkeletalTDistributionRnd {
      * 正規ガンマタイプの {@link TDistributionRnd} のファクトリインスタンスを生成する.
      * 
      * @param exponentiation 指数関数の計算
-     * @param normalRndFactory 正規乱数生成器のファクトリ
      * @param gammaRndFactory ガンマ乱数生成器のファクトリ
      * @return 乱数生成器ファクトリ
      * @throws NullPointerException 引数にnullが含まれる場合
      */
     public static TDistributionRnd.Factory createFactory(
             Exponentiation exponentiation,
-            NormalRnd.Factory normalRndFactory,
             GammaRnd.Factory gammaRndFactory) {
 
         return new Factory(
                 Objects.requireNonNull(exponentiation),
-                Objects.requireNonNull(normalRndFactory),
                 Objects.requireNonNull(gammaRndFactory));
     }
 
@@ -87,22 +81,19 @@ public final class NormalGammaBasedTDistRnd extends SkeletalTDistributionRnd {
     private static final class Factory extends SkeletalTDistributionRnd.Factory {
 
         private final Exponentiation exponentiation;
-        private final NormalRnd.Factory normalRndFactory;
         private final GammaRnd.Factory gammaRndFactory;
 
         Factory(
                 Exponentiation exponentiation,
-                NormalRnd.Factory normalRndFactory,
                 GammaRnd.Factory gammaRndFactory) {
             super();
             this.exponentiation = exponentiation;
-            this.normalRndFactory = normalRndFactory;
             this.gammaRndFactory = gammaRndFactory;
         }
 
         @Override
         TDistributionRnd createInstanceOf(double nu) {
-            return new NormalGammaBasedTDistRnd(nu, this.exponentiation, this.normalRndFactory, this.gammaRndFactory);
+            return new NormalGammaBasedTDistRnd(nu, this.exponentiation, this.gammaRndFactory);
         }
     }
 }

--- a/src/matsu/num/statistics/random/voigt/StandardImplVoigtRnd.java
+++ b/src/matsu/num/statistics/random/voigt/StandardImplVoigtRnd.java
@@ -4,8 +4,9 @@
  * This software is released under the MIT License.
  * http://opensource.org/licenses/mit-license.php
  */
+
 /*
- * 2025.6.13
+ * 2026.5.27
  */
 package matsu.num.statistics.random.voigt;
 
@@ -13,7 +14,6 @@ import java.util.Objects;
 
 import matsu.num.statistics.random.BaseRandom;
 import matsu.num.statistics.random.CauchyRnd;
-import matsu.num.statistics.random.NormalRnd;
 import matsu.num.statistics.random.VoigtRnd;
 
 /**
@@ -25,15 +25,12 @@ public final class StandardImplVoigtRnd extends SkeletalVoigtRnd {
 
     private final double reflectedAlpha;
 
-    private final NormalRnd normalRnd;
     private final CauchyRnd cauchyRnd;
 
-    private StandardImplVoigtRnd(double alpha,
-            NormalRnd.Factory normalRndFactory, CauchyRnd.Factory cauchyRndFactory) {
+    private StandardImplVoigtRnd(double alpha, CauchyRnd.Factory cauchyRndFactory) {
         super(alpha);
 
         this.reflectedAlpha = 1 - alpha;
-        this.normalRnd = normalRndFactory.instance();
         this.cauchyRnd = cauchyRndFactory.instance();
     }
 
@@ -42,7 +39,7 @@ public final class StandardImplVoigtRnd extends SkeletalVoigtRnd {
         double out;
         do {
             out = this.alpha * this.cauchyRnd.nextRandom(random)
-                    + this.reflectedAlpha * this.normalRnd.nextRandom(random);
+                    + this.reflectedAlpha * random.nextGaussian();
 
             // outが NaN　となった場合のフォロー
         } while (Double.isNaN(out));
@@ -53,33 +50,28 @@ public final class StandardImplVoigtRnd extends SkeletalVoigtRnd {
     /**
      * スタンダードな {@link VoigtRnd} のファクトリインスタンスを生成する.
      * 
-     * @param normalRndFactory 正規乱数生成器のファクトリ
      * @param cauchyRndFactory Cauchy乱数生成器のファクトリ
      * @return 乱数生成器ファクトリ
      * @throws NullPointerException 引数にnullが含まれる場合
      */
-    public static VoigtRnd.Factory createFactory(
-            NormalRnd.Factory normalRndFactory, CauchyRnd.Factory cauchyRndFactory) {
+    public static VoigtRnd.Factory createFactory(CauchyRnd.Factory cauchyRndFactory) {
 
         return new Factory(
-                Objects.requireNonNull(normalRndFactory),
                 Objects.requireNonNull(cauchyRndFactory));
     }
 
     private static final class Factory extends SkeletalVoigtRnd.Factory {
 
-        private final NormalRnd.Factory normalRndFactory;
         private final CauchyRnd.Factory cauchyRndFactory;
 
-        Factory(NormalRnd.Factory normalRndFactory, CauchyRnd.Factory cauchyRndFactory) {
+        Factory(CauchyRnd.Factory cauchyRndFactory) {
             super();
-            this.normalRndFactory = Objects.requireNonNull(normalRndFactory);
             this.cauchyRndFactory = Objects.requireNonNull(cauchyRndFactory);
         }
 
         @Override
         VoigtRnd createInstanceOf(double alpha) {
-            return new StandardImplVoigtRnd(alpha, this.normalRndFactory, this.cauchyRndFactory);
+            return new StandardImplVoigtRnd(alpha, this.cauchyRndFactory);
         }
     }
 }

--- a/src/matsu/num/statistics/random/yulesimon/ExpGeometricBasedYuleSimonRnd.java
+++ b/src/matsu/num/statistics/random/yulesimon/ExpGeometricBasedYuleSimonRnd.java
@@ -6,14 +6,13 @@
  */
 
 /*
- * 2025.6.4
+ * 2026.5.27
  */
 package matsu.num.statistics.random.yulesimon;
 
 import java.util.Objects;
 
 import matsu.num.statistics.random.BaseRandom;
-import matsu.num.statistics.random.ExponentialRnd;
 import matsu.num.statistics.random.YuleSimonRnd;
 import matsu.num.statistics.random.lib.Exponentiation;
 
@@ -36,18 +35,15 @@ public final class ExpGeometricBasedYuleSimonRnd extends SkeletalYuleSimonRnd {
     private final double invRho;
 
     private final Exponentiation exponentiation;
-    private final ExponentialRnd expRnd;
 
     /**
      * 唯一の非公開コンストラクタ.
      * 引数のバリデーションは行われていない.
      */
-    private ExpGeometricBasedYuleSimonRnd(double rho,
-            Exponentiation exponentiation, ExponentialRnd.Factory expRndFActory) {
+    private ExpGeometricBasedYuleSimonRnd(double rho, Exponentiation exponentiation) {
         super(rho);
 
         this.exponentiation = exponentiation;
-        this.expRnd = expRndFActory.instance();
 
         this.invRho = 1d / rho;
     }
@@ -55,12 +51,12 @@ public final class ExpGeometricBasedYuleSimonRnd extends SkeletalYuleSimonRnd {
     @Override
     public int nextRandom(BaseRandom random) {
         while (true) {
-            double y_invRho = expRnd.nextRandom(random) * invRho;
+            double y_invRho = random.nextExponential() * invRho;
             double invC = y_invRho < 1
                     ? -exponentiation.log(-exponentiation.expm1(-y_invRho))
                     : -exponentiation.log1p(-exponentiation.exp(-y_invRho));
 
-            double w = expRnd.nextRandom(random) / invC;
+            double w = random.nextExponential() / invC;
             if (w < Integer.MAX_VALUE - 1) {
                 return (int) w + 1;
             }
@@ -71,16 +67,13 @@ public final class ExpGeometricBasedYuleSimonRnd extends SkeletalYuleSimonRnd {
      * {@link matsu.num.statistics.random.YuleSimonRnd.Factory} を生成する.
      * 
      * @param exponentiation 指数関数の計算
-     * @param exponentialRndFactory 指数乱数発生器のファクトリ
      * @return Yule-Simon 乱数のファクトリ
      * @throws NullPointerException 引数がnullの場合
      */
     public static YuleSimonRnd.Factory createFactory(
-            Exponentiation exponentiation,
-            ExponentialRnd.Factory exponentialRndFactory) {
+            Exponentiation exponentiation) {
         return new Factory(
-                Objects.requireNonNull(exponentiation),
-                Objects.requireNonNull(exponentialRndFactory));
+                Objects.requireNonNull(exponentiation));
     }
 
     /**
@@ -90,21 +83,19 @@ public final class ExpGeometricBasedYuleSimonRnd extends SkeletalYuleSimonRnd {
     private static final class Factory extends SkeletalYuleSimonRnd.Factory {
 
         private final Exponentiation exponentiation;
-        private final ExponentialRnd.Factory expRndFActory;
 
         /**
          * 唯一の非公開コンストラクタ.
          * 引数のバリデーションは行われていない.
          */
-        Factory(Exponentiation exponentiation, ExponentialRnd.Factory expRndFActory) {
+        Factory(Exponentiation exponentiation) {
             super();
             this.exponentiation = exponentiation;
-            this.expRndFActory = expRndFActory;
         }
 
         @Override
         YuleSimonRnd createInstanceOf(double rho) {
-            return new ExpGeometricBasedYuleSimonRnd(rho, exponentiation, expRndFActory);
+            return new ExpGeometricBasedYuleSimonRnd(rho, exponentiation);
         }
     }
 }

--- a/src/matsu/num/statistics/random/zeta/RejectionSamplingZetaRnd.java
+++ b/src/matsu/num/statistics/random/zeta/RejectionSamplingZetaRnd.java
@@ -6,14 +6,13 @@
  */
 
 /*
- * 2025.6.3
+ * 2026.5.27
  */
 package matsu.num.statistics.random.zeta;
 
 import java.util.Objects;
 
 import matsu.num.statistics.random.BaseRandom;
-import matsu.num.statistics.random.ExponentialRnd;
 import matsu.num.statistics.random.ZetaRnd;
 import matsu.num.statistics.random.lib.Exponentiation;
 
@@ -51,7 +50,6 @@ public final class RejectionSamplingZetaRnd extends SkeletalZetaRnd {
     private static final double LN_0_5 = Math.log(0.5);
 
     private final Exponentiation exponentiation;
-    private final ExponentialRnd exponentialRnd;
 
     private final double s_minus_1;
     private final double inv_s_minus_1;
@@ -63,11 +61,9 @@ public final class RejectionSamplingZetaRnd extends SkeletalZetaRnd {
      * 引数チェックは行われていないので注意.
      */
     private RejectionSamplingZetaRnd(double s,
-            Exponentiation exponentiation,
-            ExponentialRnd.Factory exponentialRndFactory) {
+            Exponentiation exponentiation) {
         super(s);
         this.exponentiation = exponentiation;
-        this.exponentialRnd = exponentialRndFactory.instance();
 
         this.s_minus_1 = s - 1;
         this.inv_s_minus_1 = 1d / this.s_minus_1;
@@ -77,7 +73,7 @@ public final class RejectionSamplingZetaRnd extends SkeletalZetaRnd {
     @Override
     public int nextRandom(BaseRandom random) {
         while (true) {
-            double z = exponentiation.exp(exponentialRnd.nextRandom(random) * inv_s_minus_1);
+            double z = exponentiation.exp(random.nextExponential() * inv_s_minus_1);
             if (z > Integer.MAX_VALUE) {
                 continue;
             }
@@ -99,35 +95,30 @@ public final class RejectionSamplingZetaRnd extends SkeletalZetaRnd {
      * {@link matsu.num.statistics.random.ZetaRnd.Factory} を生成する.
      * 
      * @param exponentiation 指数関数の計算
-     * @param exponentialRndFactory 指数乱数発生器のファクトリ
      * @return ゼータ乱数のファクトリ
      * @throws NullPointerException 引数がnullの場合
      */
-    public static ZetaRnd.Factory createFactory(Exponentiation exponentiation,
-            ExponentialRnd.Factory exponentialRndFactory) {
+    public static ZetaRnd.Factory createFactory(Exponentiation exponentiation) {
         return new Factory(
-                Objects.requireNonNull(exponentiation),
-                Objects.requireNonNull(exponentialRndFactory));
+                Objects.requireNonNull(exponentiation));
     }
 
     private static final class Factory extends SkeletalZetaRnd.Factory {
 
         private final Exponentiation exponentiation;
-        private final ExponentialRnd.Factory exponentialRndFactory;
 
         /**
          * 非公開のコンストラクタ. <br>
          * 生成はstaticメソッドにより行われる.
          */
-        Factory(Exponentiation exponentiation, ExponentialRnd.Factory exponentialRndFactory) {
+        Factory(Exponentiation exponentiation) {
             super();
             this.exponentiation = exponentiation;
-            this.exponentialRndFactory = exponentialRndFactory;
         }
 
         @Override
         ZetaRnd createInstanceOf(double s) {
-            return new RejectionSamplingZetaRnd(s, exponentiation, exponentialRndFactory);
+            return new RejectionSamplingZetaRnd(s, exponentiation);
         }
     }
 }

--- a/test/matsu/num/statistics/random/gamma/GammaFactoryForTesting.java
+++ b/test/matsu/num/statistics/random/gamma/GammaFactoryForTesting.java
@@ -9,9 +9,7 @@ package matsu.num.statistics.random.gamma;
 import org.junit.Ignore;
 
 import matsu.num.statistics.random.GammaRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
-import matsu.num.statistics.random.norm.NormalFactoryForTesting;
 
 /**
  * テストクラスで使用する {@link matsu.num.statistics.random.GammaRnd.Factory}.
@@ -20,9 +18,7 @@ import matsu.num.statistics.random.norm.NormalFactoryForTesting;
 public final class GammaFactoryForTesting {
 
     public static final GammaRnd.Factory FACTORY =
-            MTTypeGammaRndFactory.create(
-                    ExponentiationForTesting.INSTANCE,
-                    ExponentialFactoryForTesting.FACTORY, NormalFactoryForTesting.FACTORY);
+            MTTypeGammaRndFactory.create(ExponentiationForTesting.INSTANCE);
 
     private GammaFactoryForTesting() {
     }

--- a/test/matsu/num/statistics/random/gamma/MTTypeGammaRndFactoryTest.java
+++ b/test/matsu/num/statistics/random/gamma/MTTypeGammaRndFactoryTest.java
@@ -19,9 +19,7 @@ import org.junit.runner.RunWith;
 import matsu.num.statistics.random.BaseRandom;
 import matsu.num.statistics.random.FloatingRandomGeneratorTestingFramework;
 import matsu.num.statistics.random.GammaRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
-import matsu.num.statistics.random.norm.NormalFactoryForTesting;
 import matsu.num.statistics.random.speedutil.SpeedTestExecutor;
 
 /**
@@ -32,9 +30,7 @@ final class MTTypeGammaRndFactoryTest {
 
     public static final Class<?> TEST_CLASS = MTTypeGammaRndFactory.class;
     private static final GammaRnd.Factory FACTORY =
-            MTTypeGammaRndFactory.create(
-                    ExponentiationForTesting.INSTANCE,
-                    ExponentialFactoryForTesting.FACTORY, NormalFactoryForTesting.FACTORY);
+            MTTypeGammaRndFactory.create(ExponentiationForTesting.INSTANCE);
 
     @SuppressWarnings("deprecation")
     public static class ファクトリの境界値テスト {

--- a/test/matsu/num/statistics/random/geo/GeometricFactoryForTesting.java
+++ b/test/matsu/num/statistics/random/geo/GeometricFactoryForTesting.java
@@ -9,7 +9,6 @@ package matsu.num.statistics.random.geo;
 import org.junit.Ignore;
 
 import matsu.num.statistics.random.GeometricRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
 
 /**
@@ -19,8 +18,7 @@ import matsu.num.statistics.random.lib.ExponentiationForTesting;
 public final class GeometricFactoryForTesting {
 
     public static final GeometricRnd.Factory FACTORY =
-            InversionBasedGeoRnd.createFactory(
-                    ExponentiationForTesting.INSTANCE, ExponentialFactoryForTesting.FACTORY);
+            InversionBasedGeoRnd.createFactory(ExponentiationForTesting.INSTANCE);
 
     private GeometricFactoryForTesting() {
     }

--- a/test/matsu/num/statistics/random/geo/InversionBasedGeoRndFactoryTest.java
+++ b/test/matsu/num/statistics/random/geo/InversionBasedGeoRndFactoryTest.java
@@ -22,7 +22,6 @@ import matsu.num.statistics.random.BaseRandom;
 import matsu.num.statistics.random.GeometricRnd;
 import matsu.num.statistics.random.IntegerRandomGeneratorTestingFramework;
 import matsu.num.statistics.random.TestedIntegerRandomGenerator;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
 
 /**
@@ -33,8 +32,7 @@ final class InversionBasedGeoRndFactoryTest {
 
     public static final Class<?> TEST_CLASS = InversionBasedGeoRnd.class;
     private static final GeometricRnd.Factory FACTORY =
-            InversionBasedGeoRnd.createFactory(
-                    ExponentiationForTesting.INSTANCE, ExponentialFactoryForTesting.FACTORY);
+            InversionBasedGeoRnd.createFactory(ExponentiationForTesting.INSTANCE);
 
     @SuppressWarnings("deprecation")
     public static class ファクトリの境界値テスト {

--- a/test/matsu/num/statistics/random/gumbel/GumbelFactoryForTesting.java
+++ b/test/matsu/num/statistics/random/gumbel/GumbelFactoryForTesting.java
@@ -9,7 +9,6 @@ package matsu.num.statistics.random.gumbel;
 import org.junit.Ignore;
 
 import matsu.num.statistics.random.GumbelRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
 
 /**
@@ -20,8 +19,7 @@ public final class GumbelFactoryForTesting {
 
     public static final GumbelRnd.Factory FACTORY =
             UniZiggGumbelRnd.createFactory(
-                    ExponentiationForTesting.INSTANCE,
-                    ExponentialFactoryForTesting.FACTORY);
+                    ExponentiationForTesting.INSTANCE);
 
     private GumbelFactoryForTesting() {
     }

--- a/test/matsu/num/statistics/random/gumbel/UniZiggGumbelRndTest.java
+++ b/test/matsu/num/statistics/random/gumbel/UniZiggGumbelRndTest.java
@@ -12,7 +12,6 @@ import org.junit.runner.RunWith;
 
 import matsu.num.statistics.random.FloatingRandomGeneratorTestingFramework;
 import matsu.num.statistics.random.GumbelRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
 
 /**
@@ -24,8 +23,7 @@ final class UniZiggGumbelRndTest {
     public static final Class<?> TEST_CLASS = UniZiggGumbelRnd.class;
     private static final GumbelRnd.Factory FACTORY =
             UniZiggGumbelRnd.createFactory(
-                    ExponentiationForTesting.INSTANCE,
-                    ExponentialFactoryForTesting.FACTORY);
+                    ExponentiationForTesting.INSTANCE);
 
     public static class 乱数のテスト {
 

--- a/test/matsu/num/statistics/random/levy/LevyFactoryForTesting.java
+++ b/test/matsu/num/statistics/random/levy/LevyFactoryForTesting.java
@@ -9,7 +9,6 @@ package matsu.num.statistics.random.levy;
 import org.junit.Ignore;
 
 import matsu.num.statistics.random.LevyRnd;
-import matsu.num.statistics.random.norm.NormalFactoryForTesting;
 
 /**
  * テストクラスで使用する {@link matsu.num.statistics.random.LevyRnd.Factory}.
@@ -21,7 +20,7 @@ import matsu.num.statistics.random.norm.NormalFactoryForTesting;
 public final class LevyFactoryForTesting {
 
     public static final LevyRnd.Factory FACTORY =
-            NormalBasedLevyRnd.createFactory(NormalFactoryForTesting.FACTORY);
+            NormalBasedLevyRnd.createFactory();
 
     private LevyFactoryForTesting() {
     }

--- a/test/matsu/num/statistics/random/levy/NormalBasedLevyRndTest.java
+++ b/test/matsu/num/statistics/random/levy/NormalBasedLevyRndTest.java
@@ -12,7 +12,6 @@ import org.junit.runner.RunWith;
 
 import matsu.num.statistics.random.FloatingRandomGeneratorTestingFramework;
 import matsu.num.statistics.random.LevyRnd;
-import matsu.num.statistics.random.norm.NormalFactoryForTesting;
 
 /**
  * {@link NormalBasedLevyRnd} クラスのテスト.
@@ -22,7 +21,7 @@ final class NormalBasedLevyRndTest {
 
     public static final Class<?> TEST_CLASS = NormalBasedLevyRnd.class;
     private static final LevyRnd.Factory FACTORY =
-            NormalBasedLevyRnd.createFactory(NormalFactoryForTesting.FACTORY);
+            NormalBasedLevyRnd.createFactory();
 
     public static class 乱数のテスト {
 

--- a/test/matsu/num/statistics/random/logi/LogisticFactoryForTesting.java
+++ b/test/matsu/num/statistics/random/logi/LogisticFactoryForTesting.java
@@ -9,7 +9,6 @@ package matsu.num.statistics.random.logi;
 import org.junit.Ignore;
 
 import matsu.num.statistics.random.LogisticRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
 
 /**
@@ -23,7 +22,7 @@ public final class LogisticFactoryForTesting {
 
     public static final LogisticRnd.Factory FACTORY =
             ZiggLogiRnd.createFactory(
-                    ExponentiationForTesting.INSTANCE, ExponentialFactoryForTesting.FACTORY);
+                    ExponentiationForTesting.INSTANCE);
 
     private LogisticFactoryForTesting() {
     }

--- a/test/matsu/num/statistics/random/logi/ZiggLogiRndTest.java
+++ b/test/matsu/num/statistics/random/logi/ZiggLogiRndTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 
 import matsu.num.statistics.random.FloatingRandomGeneratorTestingFramework;
 import matsu.num.statistics.random.LogisticRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
 
 /**
@@ -20,7 +19,7 @@ final class ZiggLogiRndTest {
 
     public static final Class<?> TEST_CLASS = ZiggLogiRnd.class;
     private static final LogisticRnd.Factory FACTORY =
-            ZiggLogiRnd.createFactory(ExponentiationForTesting.INSTANCE, ExponentialFactoryForTesting.FACTORY);
+            ZiggLogiRnd.createFactory(ExponentiationForTesting.INSTANCE);
 
     public static class Logistic乱数の生成テスト {
 

--- a/test/matsu/num/statistics/random/logseries/GeometricMixBasedLogarithmicSeriesRndTest.java
+++ b/test/matsu/num/statistics/random/logseries/GeometricMixBasedLogarithmicSeriesRndTest.java
@@ -15,7 +15,6 @@ import org.junit.runner.RunWith;
 
 import matsu.num.statistics.random.IntegerRandomGeneratorTestingFramework;
 import matsu.num.statistics.random.LogarithmicSeriesRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
 
 /**
@@ -30,8 +29,7 @@ final class GeometricMixBasedLogarithmicSeriesRndTest {
 
     private static final LogarithmicSeriesRnd.Factory FACTORY =
             GeometricMixBasedLogarithmicSeriesRnd.createFactory(
-                    ExponentiationForTesting.INSTANCE,
-                    ExponentialFactoryForTesting.FACTORY);
+                    ExponentiationForTesting.INSTANCE);
 
     @RunWith(Theories.class)
     public static class 乱数のテスト {

--- a/test/matsu/num/statistics/random/mix/TestedCategoricalBasedFloatingMixtureRnd.java
+++ b/test/matsu/num/statistics/random/mix/TestedCategoricalBasedFloatingMixtureRnd.java
@@ -11,10 +11,8 @@ import java.util.function.ToDoubleFunction;
 
 import matsu.num.statistics.random.BaseRandom;
 import matsu.num.statistics.random.BoundIntRnd;
-import matsu.num.statistics.random.ExponentialRnd;
 import matsu.num.statistics.random.TestedFloatingRandomGenerator;
 import matsu.num.statistics.random.cat.CategoricalFactoryForTesting;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 
 /**
  * {@link SimpleFloatingMixtureRnd} に関する
@@ -42,14 +40,13 @@ final class TestedCategoricalBasedFloatingMixtureRnd implements TestedFloatingRa
 
         BoundIntRnd selector = CategoricalFactoryForTesting.FACTORY.instanceOf(
                 new double[] { 5, 4, 3, 2, 1 });
-        final ExponentialRnd exponentialRnd = ExponentialFactoryForTesting.FACTORY.instance();
 
         List<ToDoubleFunction<BaseRandom>> components = List.of(
-                br -> exponentialRnd.nextRandom(br),
-                br -> exponentialRnd.nextRandom(br) + 1d,
-                br -> exponentialRnd.nextRandom(br) + 2d,
-                br -> exponentialRnd.nextRandom(br) + 3d,
-                br -> exponentialRnd.nextRandom(br) + 4d);
+                br -> br.nextExponential(),
+                br -> br.nextExponential() + 1d,
+                br -> br.nextExponential() + 2d,
+                br -> br.nextExponential() + 3d,
+                br -> br.nextExponential() + 4d);
 
         this.mixtureRnd = SimpleFloatingMixtureRnd.createFrom(selector, components);
     }

--- a/test/matsu/num/statistics/random/staticgamma/MTTypeStaticGammaRndFactoryTest.java
+++ b/test/matsu/num/statistics/random/staticgamma/MTTypeStaticGammaRndFactoryTest.java
@@ -20,9 +20,7 @@ import org.junit.runner.RunWith;
 import matsu.num.statistics.random.BaseRandom;
 import matsu.num.statistics.random.FloatingRandomGeneratorTestingFramework;
 import matsu.num.statistics.random.StaticGammaRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
-import matsu.num.statistics.random.norm.NormalFactoryForTesting;
 import matsu.num.statistics.random.speedutil.SpeedTestExecutor;
 
 /**
@@ -34,9 +32,7 @@ final class MTTypeStaticGammaRndFactoryTest {
     public static final Class<?> TEST_CLASS = MTTypeStaticGammaRnd.class;
     private static final StaticGammaRnd.Factory FACTORY =
             MTTypeStaticGammaRnd.createFactory(
-                    ExponentiationForTesting.INSTANCE,
-                    ExponentialFactoryForTesting.FACTORY,
-                    NormalFactoryForTesting.FACTORY);
+                    ExponentiationForTesting.INSTANCE);
 
     @SuppressWarnings("deprecation")
     public static class パラメータの境界値テスト {

--- a/test/matsu/num/statistics/random/staticgamma/StaticGammaFactoryForTesting.java
+++ b/test/matsu/num/statistics/random/staticgamma/StaticGammaFactoryForTesting.java
@@ -9,9 +9,7 @@ package matsu.num.statistics.random.staticgamma;
 import org.junit.Ignore;
 
 import matsu.num.statistics.random.StaticGammaRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
-import matsu.num.statistics.random.norm.NormalFactoryForTesting;
 
 /**
  * テストクラスで使用する {@link matsu.num.statistics.random.StaticGammaRnd.Factory}.
@@ -21,9 +19,7 @@ public final class StaticGammaFactoryForTesting {
 
     public static final StaticGammaRnd.Factory FACTORY =
             MTTypeStaticGammaRnd.createFactory(
-                    ExponentiationForTesting.INSTANCE,
-                    ExponentialFactoryForTesting.FACTORY,
-                    NormalFactoryForTesting.FACTORY);
+                    ExponentiationForTesting.INSTANCE);
 
     private StaticGammaFactoryForTesting() {
     }

--- a/test/matsu/num/statistics/random/tdist/NormalGammaBasedTDistRndFactoryTest.java
+++ b/test/matsu/num/statistics/random/tdist/NormalGammaBasedTDistRndFactoryTest.java
@@ -24,7 +24,6 @@ import matsu.num.statistics.random.TDistributionRnd;
 import matsu.num.statistics.random.TestedFloatingRandomGenerator;
 import matsu.num.statistics.random.gamma.GammaFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
-import matsu.num.statistics.random.norm.NormalFactoryForTesting;
 
 /**
  * {@link NormalGammaBasedTDistRnd} クラスのテスト.
@@ -36,7 +35,6 @@ final class NormalGammaBasedTDistRndFactoryTest {
     private static final TDistributionRnd.Factory FACTORY =
             NormalGammaBasedTDistRnd.createFactory(
                     ExponentiationForTesting.INSTANCE,
-                    NormalFactoryForTesting.FACTORY,
                     GammaFactoryForTesting.FACTORY);
 
     @SuppressWarnings("deprecation")

--- a/test/matsu/num/statistics/random/tdist/TDistFactoryForTesting.java
+++ b/test/matsu/num/statistics/random/tdist/TDistFactoryForTesting.java
@@ -11,7 +11,6 @@ import org.junit.Ignore;
 import matsu.num.statistics.random.TDistributionRnd;
 import matsu.num.statistics.random.gamma.GammaFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
-import matsu.num.statistics.random.norm.NormalFactoryForTesting;
 
 /**
  * テストクラスで使用する {@link matsu.num.statistics.random.TDistributionRnd.Factory}.
@@ -25,7 +24,6 @@ public final class TDistFactoryForTesting {
     public static final TDistributionRnd.Factory FACTORY =
             NormalGammaBasedTDistRnd.createFactory(
                     ExponentiationForTesting.INSTANCE,
-                    NormalFactoryForTesting.FACTORY,
                     GammaFactoryForTesting.FACTORY);
 
     private TDistFactoryForTesting() {

--- a/test/matsu/num/statistics/random/voigt/StandardImplVoigtRndFactoryTest.java
+++ b/test/matsu/num/statistics/random/voigt/StandardImplVoigtRndFactoryTest.java
@@ -23,7 +23,6 @@ import matsu.num.statistics.random.FloatingRandomGeneratorTestingFramework;
 import matsu.num.statistics.random.TestedFloatingRandomGenerator;
 import matsu.num.statistics.random.VoigtRnd;
 import matsu.num.statistics.random.cauchy.CauchyFactoryForTesting;
-import matsu.num.statistics.random.norm.NormalFactoryForTesting;
 
 /**
  * {@link StandardImplVoigtRnd} クラスのテスト.
@@ -33,7 +32,7 @@ final class StandardImplVoigtRndFactoryTest {
 
     public static final Class<?> TEST_CLASS = StandardImplVoigtRnd.class;
     private static final VoigtRnd.Factory FACTORY =
-            StandardImplVoigtRnd.createFactory(NormalFactoryForTesting.FACTORY, CauchyFactoryForTesting.FACTORY);
+            StandardImplVoigtRnd.createFactory(CauchyFactoryForTesting.FACTORY);
 
     @SuppressWarnings("deprecation")
     public static class ファクトリの境界値テスト {

--- a/test/matsu/num/statistics/random/voigt/VoigtFactoryForTesting.java
+++ b/test/matsu/num/statistics/random/voigt/VoigtFactoryForTesting.java
@@ -10,7 +10,6 @@ import org.junit.Ignore;
 
 import matsu.num.statistics.random.VoigtRnd;
 import matsu.num.statistics.random.cauchy.CauchyFactoryForTesting;
-import matsu.num.statistics.random.norm.NormalFactoryForTesting;
 
 /**
  * テストクラスで使用する {@link matsu.num.statistics.random.VoigtRnd.Factory}.
@@ -23,7 +22,7 @@ public final class VoigtFactoryForTesting {
 
     public static final VoigtRnd.Factory FACTORY =
             StandardImplVoigtRnd.createFactory(
-                    NormalFactoryForTesting.FACTORY, CauchyFactoryForTesting.FACTORY);
+                    CauchyFactoryForTesting.FACTORY);
 
     private VoigtFactoryForTesting() {
     }

--- a/test/matsu/num/statistics/random/yulesimon/ExpGeometricBasedYuleSimonRndTest.java
+++ b/test/matsu/num/statistics/random/yulesimon/ExpGeometricBasedYuleSimonRndTest.java
@@ -15,7 +15,6 @@ import org.junit.runner.RunWith;
 
 import matsu.num.statistics.random.IntegerRandomGeneratorTestingFramework;
 import matsu.num.statistics.random.YuleSimonRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
 
 /**
@@ -28,8 +27,7 @@ final class ExpGeometricBasedYuleSimonRndTest {
 
     private static final YuleSimonRnd.Factory FACTORY =
             ExpGeometricBasedYuleSimonRnd.createFactory(
-                    ExponentiationForTesting.INSTANCE,
-                    ExponentialFactoryForTesting.FACTORY);
+                    ExponentiationForTesting.INSTANCE);
 
     @RunWith(Theories.class)
     public static class 乱数のテスト {

--- a/test/matsu/num/statistics/random/zeta/RejectionSamplingZetaRndTest.java
+++ b/test/matsu/num/statistics/random/zeta/RejectionSamplingZetaRndTest.java
@@ -17,7 +17,6 @@ import org.junit.runner.RunWith;
 import matsu.num.statistics.random.BaseRandom;
 import matsu.num.statistics.random.IntegerRandomGeneratorTestingFramework;
 import matsu.num.statistics.random.ZetaRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
 import matsu.num.statistics.random.speedutil.SpeedTestExecutor;
 
@@ -31,8 +30,7 @@ final class RejectionSamplingZetaRndTest {
 
     private static final ZetaRnd.Factory FACTORY =
             RejectionSamplingZetaRnd.createFactory(
-                    ExponentiationForTesting.INSTANCE,
-                    ExponentialFactoryForTesting.FACTORY);
+                    ExponentiationForTesting.INSTANCE);
 
     @RunWith(Theories.class)
     public static class 乱数のテスト {

--- a/test/matsu/num/statistics/random/zeta/ZetaRndFactoryForTesting.java
+++ b/test/matsu/num/statistics/random/zeta/ZetaRndFactoryForTesting.java
@@ -13,7 +13,6 @@ package matsu.num.statistics.random.zeta;
 import org.junit.Ignore;
 
 import matsu.num.statistics.random.ZetaRnd;
-import matsu.num.statistics.random.exp.ExponentialFactoryForTesting;
 import matsu.num.statistics.random.lib.ExponentiationForTesting;
 
 /**
@@ -26,8 +25,7 @@ public final class ZetaRndFactoryForTesting {
 
     public static final ZetaRnd.Factory FACTORY =
             RejectionSamplingZetaRnd.createFactory(
-                    ExponentiationForTesting.INSTANCE,
-                    ExponentialFactoryForTesting.FACTORY);
+                    ExponentiationForTesting.INSTANCE);
 
     private ZetaRndFactoryForTesting() {
         //インスタンス化不可


### PR DESCRIPTION
for issue #74 
既存乱数発生器の内部でExponentialRndとNormalRndを使用することを避ける